### PR TITLE
Update README to eliminate confusion with vanilla Project64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# RAP64
+# RAProject64
 
-RAP64 is a fork of Project64, a free and open-source emulator for the Nintendo 64 and Nintendo 64 Disk Drive written in C++ currently only for Windows (planned support for other platforms in the future).
+RAProject64 is a fork of Project64, a free and open-source emulator for the Nintendo 64 and Nintendo 64 Disk Drive written in C++ currently only for Windows (planned support for other platforms in the future).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-<p align="center">
-  <img src="./Docs/img/icon.png" alt="logo" width="200" />
-</p>
+# RAP64
 
-# Project64
-
-Project64 is a free and open-source emulator for the Nintendo 64 and Nintendo 64 Disk Drive written in C++ currently only for Windows (planned support for other platforms in the future).
+RAP64 is a fork of Project64, a free and open-source emulator for the Nintendo 64 and Nintendo 64 Disk Drive written in C++ currently only for Windows (planned support for other platforms in the future).
 
 ## Features
 
@@ -14,23 +10,11 @@ Project64 is a free and open-source emulator for the Nintendo 64 and Nintendo 64
 - Controller support
 - Great language support
 - Support for many popular N64 emulator plugins
-
-## Screenshot
-
-<p align="center">
-  <img src="./Docs/img/screen.png" alt="screenshot" width="400" />
-</p>
+- RetroAchievements support (requires an account)
 
 ## Installation
 
-Installer for the latest stable releases are available [here](https://www.pj64-emu.com/windows-downloads).
-
-Download nightly builds [here](https://www.pj64-emu.com/nightly-builds).
-
-AppVeyor (Windows x86/x64): [![Build status](https://ci.appveyor.com/api/projects/status/sbtwyhaexslyhgx3?svg=true
-)](https://ci.appveyor.com/project/project64/project64/branch/develop)
-
-*Side note: 64-bit builds are considered experimental and aren't currently supported*
+Installer for the latest stable releases are available [here](hhttps://retroachievements.org/download.php#rap64).
 
 ## Minimum requirements
 
@@ -49,13 +33,7 @@ AppVeyor (Windows x86/x64): [![Build status](https://ci.appveyor.com/api/project
 
 ## Support
 
-For support, we ask all users read our [support document](./Docs/SUPPORT.md). Read this ***before*** opening issues.
-
-Please join our [Discord server](https://discord.gg/Cg3zquF) for support, questions, etc.
-
-## Changelog
-
-If you would like to see a changelog that is available [here](./Docs/CHANGELOG.md).
+Please join our [Discord server](https://discord.gg/dq2E4hE) for support, questions, etc.
 
 ## Dependencies
 
@@ -67,15 +45,9 @@ If you would like to see a changelog that is available [here](./Docs/CHANGELOG.m
 - DirectX: Copyright (C) Microsoft
 - [Windows Template Library](https://wtl.sourceforge.io/): Common Public License
 
-## Contributing
+## Original maintainers and contributors
 
-Contributions are always welcome!
-
-See the [contributing](./.github/CONTRIBUTING.md) file for ways to get started.
-
-## Maintainers and contributors
-
-- [@Project64](https://www.github.com/project64) - Zilmar - current maintainer
+- Zilmar - current maintainer of the main version
 - Jabo - Previous contributor
 - Smiff - Previous contributor
 - Gent - Previous contributor
@@ -83,8 +55,8 @@ See the [contributing](./.github/CONTRIBUTING.md) file for ways to get started.
 Also see the list of [community contributors](https://github.com/project64/project64/contributors).
 
 ## 🔗 Links
-- [Website](https://pj64-emu.com)
-- [Discord](https://discord.gg/Cg3zquF)
+- [Website](https://retroachievements.org/)
+- [Discord](https://discord.gg/dq2E4hE)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ RAP64 is a fork of Project64, a free and open-source emulator for the Nintendo 6
 
 ## Installation
 
-Installer for the latest stable releases are available [here](hhttps://retroachievements.org/download.php#rap64).
+Installer for the latest stable releases are available [here](https://retroachievements.org/download.php#rap64).
 
 ## Minimum requirements
 

--- a/Source/Project64/UserInterface/MainMenu.cpp
+++ b/Source/Project64/UserInterface/MainMenu.cpp
@@ -646,8 +646,8 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
         g_Settings->SaveDword(Game_CurrentSaveState, (DWORD)((MenuID - ID_CURRENT_SAVE_1) + 1));
         break;
     case ID_HELP_SUPPORT_PROJECT64: OnSupportProject64(hWnd); break;
-    case ID_HELP_DISCORD: ShellExecute(nullptr, L"open", L"https://discord.gg/Cg3zquF", nullptr, nullptr, SW_SHOWMAXIMIZED); break;
-    case ID_HELP_WEBSITE: ShellExecute(nullptr, L"open", L"http://www.pj64-emu.com", nullptr, nullptr, SW_SHOWMAXIMIZED); break;
+    case ID_HELP_DISCORD: ShellExecute(nullptr, L"open", L"https://discord.gg/dq2E4hE", nullptr, nullptr, SW_SHOWMAXIMIZED); break;
+    case ID_HELP_WEBSITE: ShellExecute(nullptr, L"open", L"https://retroachievements.org/", nullptr, nullptr, SW_SHOWMAXIMIZED); break;
     case ID_HELP_ABOUT: CAboutDlg(m_Gui->Support()).DoModal(); break;
     default:
         if (MenuID >= ID_RECENT_ROM_START && MenuID < ID_RECENT_ROM_END)


### PR DESCRIPTION
Update README to eliminate confusion with vanilla Project64.

We (the Project64 development team) have been getting a lot of people coming into the main Project64 server and asking for help with Project64-RA/RAProject64/RAP64. We do our best to help, but sometimes it isn't the appropriate place to ask for help when they are asking about tools and things only available in your emulator and not ours.

One quick thing, it seems there are multiple names used on the RA website and here for the emulator, so it'd be nice to know the official name and have all of the relevant places have the same name for recognition.

This replaces all links to the Project64 website and Discord with the RetroAchievements website and Discord.

It also removes the Project64 logo from the README and explains that it is a fork near the top. I also removed some references to the Project64 repo in case those things change at some point (which ideally they would be changed to references to this repo instead).

Side note: I (DerekTurtleRoe) would love to try and get this functionality merged into the main version of Project64, but the main repo is mostly undergoing large rewrites of the emulator core, and the entire UI is going to be swapped out for something else in the future. Some dependencies are also going to be removed. But at some point we would love to have a conversation about adding RA support to the main build so that you all didn't need to maintain a separate fork of the emulator with support.

If there are any questions, comments, or concerns, please feel free to ask me! 😄 

### Proposed changes
  - Update README
  - That's it!

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes.